### PR TITLE
Parse out leading colon for last line

### DIFF
--- a/HeyGirlie/Assets/Scripts/HGGOptionsListView.cs
+++ b/HeyGirlie/Assets/Scripts/HGGOptionsListView.cs
@@ -138,6 +138,10 @@ namespace Yarn.Unity
                             lastLineCharacterNameText.text = lastSeenLine.CharacterName;
                         }
                     }
+                    else if (line.Text[0] == ':')
+                    {
+                        line.Text = line.Text.Substring(1);
+                    }
 
                     if (palette != null)
                     {


### PR DESCRIPTION
Can edit these into a Yarn script to test the scenarios of speaker, no speaker, and no speaker with leading colon:
```
K2: Blimey! (British accent)
  -> Kristen: "What the hell are you doing in this game?
K2 looks you in the eye.
   -> <i>Shudder.</i>
:There's only one thing left to do: send her back.
   -> <i>Send her back.</i>
```