### PR TITLE
Implement Cassandra's week-end recap on date success

### DIFF
--- a/HeyGirlie/Assets/Scripts/Managers/GameManager.cs
+++ b/HeyGirlie/Assets/Scripts/Managers/GameManager.cs
@@ -39,6 +39,8 @@ public class GameManager : MonoBehaviour
     public Queue<string> awayDates;
 
     public bool pauseLock = false;
+    // Tracking date success
+    public int weeklyDate1, weeklyDate2, weeklyDate3;
 
     private void Awake()
     {
@@ -277,5 +279,41 @@ public class GameManager : MonoBehaviour
     public LoveInterest[] GetLIArray()
     {
         return _loveInterests;
+    }
+
+    public void UpdateDateQuality(int weeklyDateNum, int earned, int total)
+    {
+        int quality; // Bad = 0, Mid = 1, Good = 2
+        if (earned < total / 3) quality = 0;
+        else if (earned < 2 * total / 3) quality = 1;
+        else quality = 2;
+        switch (weeklyDateNum)
+        {
+            case 0:
+                weeklyDate1 = quality;
+                break;
+            case 1:
+                weeklyDate2 = quality;
+                break;
+            default:
+                weeklyDate3 = quality;
+                break;
+        }
+        Debug.Log(weeklyDateNum + " quality = " + quality);
+    }
+
+    public int GetQuality(int weeklyDateNum)
+    {
+        Debug.Log("GetQuality: " + weeklyDateNum);
+        Debug.Log (weeklyDate1 + " | " + weeklyDate2 + " | " + weeklyDate3);
+        switch (weeklyDateNum)
+        {
+            case 1: // CORRECTLY NUMBERED despite mismatch with UpdateDateQuality (variable update order means this is correct. yes i know it is confusing but it doesn't matter outside of this function so not changing it.)
+                return weeklyDate1;
+            case 2:
+                return weeklyDate2;
+            default:
+                return weeklyDate3;
+        }
     }
 }

--- a/HeyGirlie/Assets/Scripts/YarnCommands.cs
+++ b/HeyGirlie/Assets/Scripts/YarnCommands.cs
@@ -47,10 +47,8 @@ public class YarnCommands : MonoBehaviour
         dialogueRunner.AddCommandHandler("increase_dates_this_week", IncreaseDatesThisWeek);
         dialogueRunner.AddCommandHandler("next_week", NextWeek);
 
-
         dialogueRunner.AddCommandHandler<int>("setLIPriority", SetLIPriority);
         
-
         // Add Yarn Command to set Kristen sprite by calling "kristen" + sprite file name
         dialogueRunner.AddCommandHandler<string>("kristen", SetKristenSprite);
         dialogueRunner.AddCommandHandler<string>("Kristen", SetKristenSprite);
@@ -85,6 +83,7 @@ public class YarnCommands : MonoBehaviour
         dialogueRunner.AddCommandHandler<string>("toggleText", ToggleText);
         
         dialogueRunner.AddCommandHandler<int>("get_special_event_fail", GetSpecialEventFail);
+        dialogueRunner.AddCommandHandler("update_date_points", UpdateDatePoints);
     }
 
     void Start()
@@ -106,6 +105,7 @@ public class YarnCommands : MonoBehaviour
     private void AddPoints(int num)
     {
         _loveInterest.AddPoints(num);
+        if (num != 0) GameObject.Find("PointsDisplay").GetComponent<PointsDisplay>().UpdatePoints(); // Slow but only used for testing... 
         // Handling Cassandra
         float date_points; // Yarn Spinner works better with float than int for some reason (throws errors if I try to make this int)
         _variableStorage.TryGetValue("$date_points", out date_points);
@@ -113,6 +113,22 @@ public class YarnCommands : MonoBehaviour
 
         if (num != 0) GameObject.Find("PointsDisplay").GetComponent<PointsDisplay>().UpdatePoints(); // Slow but only used for testing... 
     }
+
+    private void UpdateDatePoints()
+    {
+        float date_points;
+        _variableStorage.TryGetValue("$date_points", out date_points);
+        float date_points_total;
+        _variableStorage.TryGetValue("$date_points_total", out date_points_total);
+        GameManager.Instance.UpdateDateQuality(GameManager.Instance.GetDatesThisWeek(), (int)date_points, (int)date_points_total);
+    }
+    
+    [YarnFunction("get_date_quality")]
+    public static int GetDateQuality(int weeklyDateNum)
+    {
+        return GameManager.Instance.GetQuality(weeklyDateNum);
+    }
+
 
     private void IncrementDateCount()
     {

--- a/HeyGirlie/Assets/Yarn Scripts/Cassandra/CassandraIntro.yarn
+++ b/HeyGirlie/Assets/Yarn Scripts/Cassandra/CassandraIntro.yarn
@@ -1,6 +1,6 @@
 ﻿title: Intro
-tags:
 ---
+<<declare $date_quality = 0>>
 <<kristen Neutral>>
 <<char_right CassandraNeutral>>
 
@@ -29,28 +29,33 @@ tags:
 
 <<elseif get_week() == 3>>
     <<voiceline CassGreeting1>>
-    Cassandra: WEEK 3 NOW
+    Cassandra: RECAPPING WEEK 2
+    <<jump CassTesting>>
 
 <<elseif get_week() == 4>>
     <<voiceline CassGreeting1>>
-    Cassandra: WEEK 4 NOW
+    Cassandra: RECAPPING WEEK 3
+    <<jump CassTesting>>
 
 <<elseif get_week() == 5>>
     <<voiceline CassGreeting1>>
-    Cassandra: WEEK 5 NOW
+    Cassandra: RECAPPING WEEK 4
     <<jump CassandraWeek5>>
 
 <<elseif get_week() == 6>>
     <<voiceline CassGreeting1>>
-    Cassandra: WEEK 6 NOW
+    Cassandra: RECAPPING WEEK 5
+    <<jump CassTesting>>
 
 <<elseif get_week() == 7>>
     <<voiceline CassGreeting1>>
-    Cassandra: WEEK 7 NOW
+    Cassandra: RECAPPING WEEK 6
+    <<jump CassTesting>>
 
 <<elseif get_week() == 8>>
     <<voiceline CassGreeting1>>
-    Cassandra: WEEK 8 NOW
+    Cassandra: RECAPPING WEEK 7
+    <<jump CassTesting>>
 
 <<else>>
     Cassandra: ??? how did u get here
@@ -63,18 +68,7 @@ Cassandra: Well, why don't you choose where you want to have a meet-cute (or two
 <<change_scene DateSelection>>
 ===
 
-title: CassandraWeek2
-tags:
----
-Cassandra: WEEK 2 NOW
-
-Cassandra: Where do you want to go this week?
-<<change_scene DateSelection>>
-===
-
-
 title: CassandraWeek1
-tags:
 ---
 Cassandra: WEEK 1 NOW
 <<voiceline CassNeutral2>>
@@ -97,6 +91,76 @@ Cassandra: Where do you want to go this week?
 <<change_scene DateSelection>>
 
 ===
+
+title: CassTesting
+---
+Cassandra: So... about your first date this week...
+<<if get_date_quality(1) == 0>>
+    Cassandra: You did BAD... Kristen, you need to lock the fuck in. Or else I'LL die too.
+<<elseif get_date_quality(1) == 1>>
+    Cassandra: Well, that wasn't... too bad...
+<<else>>
+    Cassandra: They should call you Rizzsten <3
+<<endif>>
+// Date 2
+Cassandra: And the second...
+<<if get_date_quality(2) == 0>>
+    Cassandra: You did BAD... Kristen, you need to lock the fuck in. Or else I'LL die too.
+<<elseif get_date_quality(2) == 1>>
+    Cassandra: Well, that wasn't... too bad...
+<<else>>
+    Cassandra: They should call you Rizzsten <3
+<<endif>>
+// Date 3
+Cassandra: Saving the best for last...
+<<if get_date_quality(3) == 0>>
+    Cassandra: You did BAD... Kristen, you need to lock the fuck in. Or else I'LL die too.
+<<elseif get_date_quality(3) == 1>>
+    Cassandra: Well, that wasn't... too bad...
+<<else>>
+    Cassandra: They should call you Rizzsten <3
+<<endif>>
+START OF NEXT WEEK NOW
+Cassandra: Where do you want to go this week?
+<<change_scene DateSelection>>
+===
+
+title: CassandraWeek2
+---
+Cassandra: Recapping your week 1...
+// Date 1
+Cassandra: So... about your first date this week...
+<<if get_date_quality(1) == 0>>
+    Cassandra: You did BAD... Kristen, you need to lock the fuck in. Or else I'LL die too.
+<<elseif get_date_quality(1) == 1>>
+    Cassandra: Well, that wasn't... too bad...
+<<else>>
+    Cassandra: They should call you Rizzsten <3
+<<endif>>
+// Date 2
+Cassandra: And the second...
+<<if get_date_quality(2) == 0>>
+    Cassandra: You did BAD... Kristen, you need to lock the fuck in. Or else I'LL die too.
+<<elseif get_date_quality(2) == 1>>
+    Cassandra: Well, that wasn't... too bad...
+<<else>>
+    Cassandra: They should call you Rizzsten <3
+<<endif>>
+// Date 3
+Cassandra: Saving the best for last...
+<<if get_date_quality(3) == 0>>
+    Cassandra: You did BAD... Kristen, you need to lock the fuck in. Or else I'LL die too.
+<<elseif get_date_quality(3) == 1>>
+    Cassandra: Well, that wasn't... too bad...
+<<else>>
+    Cassandra: They should call you Rizzsten <3
+<<endif>>
+
+Cassandra: WEEK 2 NOW
+Cassandra: Where do you want to go this week?
+<<change_scene DateSelection>>
+===
+
 
 title: CassandraWeek5
 ---
@@ -121,5 +185,9 @@ title: CassandraWeek5
 <<else>>
     Cassandra: Hmm... never mind.
 <<endif>>
+
+<<jump CassTesting>>
+
+Cassandra: WEEK 5 NOW
 <<change_scene DateSelection>>
 ===

--- a/HeyGirlie/Assets/Yarn Scripts/Routes/3Cleric/3ClericCassandra.yarn
+++ b/HeyGirlie/Assets/Yarn Scripts/Routes/3Cleric/3ClericCassandra.yarn
@@ -1,5 +1,4 @@
 ﻿title: Cassandra
-tags:
 ---
 teehee cass time
 <<sfx ring>>
@@ -19,8 +18,8 @@ Cassandra: Did you notice how I said something depending on how you did with 3C?
 ===
 
 title: EndDate
-tags:
 ---
+<<update_date_points>>
 <<increment_date_count>>
 <<increase_dates_this_week>>
 <<if get_dates_this_week() < 3>>

--- a/HeyGirlie/Assets/Yarn Scripts/Routes/FKB/FkbCassandra.yarn
+++ b/HeyGirlie/Assets/Yarn Scripts/Routes/FKB/FkbCassandra.yarn
@@ -1,5 +1,4 @@
 ﻿title: Cassandra
-tags:
 ---
 teehee cass time
 <<sfx ring>>
@@ -18,8 +17,8 @@ Cassandra: Did you notice how I said something depending on how you did with FKB
 ===
 
 title: EndDate
-tags:
 ---
+<<update_date_points>>
 <<increment_date_count>>
 <<increase_dates_this_week>>
 <<if get_dates_this_week() < 3>>

--- a/HeyGirlie/Assets/Yarn Scripts/Routes/Fig/FigCassandra.yarn
+++ b/HeyGirlie/Assets/Yarn Scripts/Routes/Fig/FigCassandra.yarn
@@ -1,5 +1,4 @@
 ﻿title: Cassandra
-tags:
 ---
 <<sfx ring>>
 teehee cass time
@@ -18,8 +17,8 @@ Cassandra: Did you notice how I said something depending on how you did with Fig
 ===
 
 title: EndDate
-tags:
 ---
+<<update_date_points>>
 <<increment_date_count>>
 <<increase_dates_this_week>>
 <<if get_dates_this_week() < 3>>

--- a/HeyGirlie/Assets/Yarn Scripts/Routes/Gertie/GertieCassandra.yarn
+++ b/HeyGirlie/Assets/Yarn Scripts/Routes/Gertie/GertieCassandra.yarn
@@ -1,5 +1,4 @@
 ﻿title: Cassandra
-tags:
 ---
 teehee cass time
 <<sfx ring>>
@@ -18,8 +17,8 @@ Cassandra: Did you notice how I said something depending on how you did with Ger
 ===
 
 title: EndDate
-tags:
 ---
+<<update_date_points>>
 <<increment_date_count>>
 <<increase_dates_this_week>>
 <<if get_dates_this_week() < 3>>

--- a/HeyGirlie/Assets/Yarn Scripts/Routes/Kipperlilly/KipCassandra.yarn
+++ b/HeyGirlie/Assets/Yarn Scripts/Routes/Kipperlilly/KipCassandra.yarn
@@ -1,5 +1,4 @@
 ﻿title: Cassandra
-tags:
 ---
 teehee cass time
 <<sfx ring>>
@@ -21,6 +20,7 @@ Cassandra: Did you notice how I said something depending on how you did with Kip
 title: EndDate
 tags:
 ---
+<<update_date_points>>
 <<increment_date_count>>
 <<increase_dates_this_week>>
 <<if get_dates_this_week() < 3>>

--- a/HeyGirlie/Assets/Yarn Scripts/Routes/Lucy/LucyCassandra.yarn
+++ b/HeyGirlie/Assets/Yarn Scripts/Routes/Lucy/LucyCassandra.yarn
@@ -1,5 +1,4 @@
 ﻿title: Cassandra
-tags:
 ---
 teehee cass time
 <<sfx ring>>
@@ -21,6 +20,7 @@ Cassandra: Did you notice how I said something depending on how you did with Luc
 title: EndDate
 tags:
 ---
+<<update_date_points>>
 <<increment_date_count>>
 <<increase_dates_this_week>>
 <<if get_dates_this_week() < 3>>

--- a/HeyGirlie/Assets/Yarn Scripts/Routes/Nara/NaradrielCassandra.yarn
+++ b/HeyGirlie/Assets/Yarn Scripts/Routes/Nara/NaradrielCassandra.yarn
@@ -1,5 +1,4 @@
 ﻿title: Cassandra
-tags:
 ---
 teehee cass time
 <<sfx ring>>
@@ -19,8 +18,8 @@ Cassandra: Did you notice how I said something depending on how you did with Nar
 ===
 
 title: EndDate
-tags:
 ---
+<<update_date_points>>
 <<increment_date_count>>
 <<increase_dates_this_week>>
 <<if get_dates_this_week() < 3>>

--- a/HeyGirlie/Assets/Yarn Scripts/Routes/Tracker/TrackerCassandra.yarn
+++ b/HeyGirlie/Assets/Yarn Scripts/Routes/Tracker/TrackerCassandra.yarn
@@ -1,5 +1,4 @@
 ﻿title: Cassandra
-tags:
 ---
 teehee cass time
 <<sfx ring>>
@@ -18,8 +17,8 @@ Cassandra: Did you notice how I said something depending on how you did with Tra
 ===
 
 title: EndDate
-tags:
 ---
+<<update_date_points>>
 <<increment_date_count>>
 <<increase_dates_this_week>>
 <<if get_dates_this_week() < 3>>


### PR DESCRIPTION
Note: most dates don't have the total date points included, so I just tested by hitting the "Cass" button and checking whether the end-of-week Cass comment matched the quality level (can see with Debug Logs) and whatever Cass said after that date

- Will need to update save system to account for weeklyDate1, weeklyDate2, weeklyDate3 variables
- Cassandra is NOT going to appear after each date in the final version, but I'm leaving her for easier testing (can check whether her response at the end of the week matches the response after the date)

*DO NOT MERGE AFTER APPROVING* (I want to remove all the testing stuff first + low priority for this week because no actual Cass content updates)