### PR TITLE
Change option view selection indicator + option alignment

### DIFF
--- a/HeyGirlie/Assets/Prefabs/Dialogue/HGG Option View.prefab
+++ b/HeyGirlie/Assets/Prefabs/Dialogue/HGG Option View.prefab
@@ -358,7 +358,7 @@ MonoBehaviour:
     m_Right: 0
     m_Top: 0
     m_Bottom: 0
-  m_ChildAlignment: 0
+  m_ChildAlignment: 3
   m_Spacing: 0
   m_ChildForceExpandWidth: 0
   m_ChildForceExpandHeight: 0


### PR DESCRIPTION
- In horizontal layout component of HGG Option View prefab, changed alignment from upper left to middle left