### PR TITLE
Update Settings.cs max vol fields

### DIFF
--- a/HeyGirlie/Assets/Scripts/UI/Settings.cs
+++ b/HeyGirlie/Assets/Scripts/UI/Settings.cs
@@ -13,7 +13,8 @@ public class Settings : Menu
     [SerializeField] private Slider cursorSlider, musicSlider, sfxSlider, voicesSlider, speedSlider, textSizeSlider; 
     [SerializeField] private Toggle autoforwardToggle;
 
-    public static float maxMusicVol, maxSfxVol, maxVoiceVol;
+    // these values determine the default volume when a player loads the game for the very first time; match to max slider value in inspector once music is finalized
+    public static float maxMusicVol = 0.2f, maxSfxVol = 0.4f, maxVoiceVol = 1f; 
 
     [SerializeField] private GameObject saveProfilesMenu;
 


### PR DESCRIPTION
- Assigned values to max vol fields so that volume doesn't start at 0 when players loads game for the very first time
- **NOTE:** match the values to the max slider values in Settings Menu.prefab once music is finalized