### PR TITLE
Create menuOpen bool in GameManager

### DIFF
--- a/HeyGirlie/Assets/Scripts/DialogueView/HGGLineView.cs
+++ b/HeyGirlie/Assets/Scripts/DialogueView/HGGLineView.cs
@@ -593,6 +593,7 @@ namespace Yarn.Unity
         /// <inheritdoc/>
         public override void UserRequestedViewAdvancement()
         {
+            if (GameManager.Instance.menuOpen) return;
             // We received a request to advance the view. If we're in the middle of
             // an animation, skip to the end of it. If we're not current in an
             // animation, interrupt the line so we can skip to the next one.

--- a/HeyGirlie/Assets/Scripts/Managers/GameManager.cs
+++ b/HeyGirlie/Assets/Scripts/Managers/GameManager.cs
@@ -40,6 +40,7 @@ public class GameManager : MonoBehaviour
 
     public bool pauseLock = false;
     public EscLock escLock = EscLock.Dropdown;
+    public bool menuOpen = false;
 
     private void Awake()
     {

--- a/HeyGirlie/Assets/Scripts/UI/Credits.cs
+++ b/HeyGirlie/Assets/Scripts/UI/Credits.cs
@@ -15,6 +15,7 @@ public class Credits : Menu
     [SerializeField] private Sprite[] pageTopFrames;
 
     void Awake(){
+        GameManager.Instance.menuOpen = true;
         Pause();
         LockEsc(EscLock.Credits);
         gameObject.GetComponent<ArrowNavigation>().ArrowKeyStart();
@@ -31,6 +32,7 @@ public class Credits : Menu
     }
 
     void OnDestroy(){
+        GameManager.Instance.menuOpen = false;
         Unpause();
         UnlockEsc();
         gameObject.GetComponent<ArrowNavigation>().ArrowKeyEnd();

--- a/HeyGirlie/Assets/Scripts/UI/Settings.cs
+++ b/HeyGirlie/Assets/Scripts/UI/Settings.cs
@@ -39,7 +39,8 @@ public class Settings : Menu
 
     protected IEnumerator WaitAwake(){
         LockEsc(EscLock.Settings);
-        Pause();
+        Pause(); // Game is already paused when this is called, so nothing happens. The game unpauses when dropdown is destroyed.
+        GameManager.Instance.menuOpen = true;
 
         if(SettingManager.Instance.fastForwardActive){
             speedSlider.interactable = false;
@@ -69,6 +70,7 @@ public class Settings : Menu
     }
 
     void OnDestroy(){
+        GameManager.Instance.menuOpen = false;
         Unpause();
         UnlockEsc();
         gameObject.GetComponent<ArrowNavigation>().ArrowKeyEnd();


### PR DESCRIPTION
Bug: able to advance dialogue with spacebar when settings, options, or credits are open

Cause: game is unpaused when settings, options, or credits are open

Order of events: open dropdown -> game pauses (call from Dropdown) -> open settings -> game pauses (call from Settings/Credits) -> dropdown closes -> game unpauses (call from Dropdown)

Created bandaid fix of a menuOpen bool in GameManager, but this doesn't handle the issue of autoforward playing while menus are open